### PR TITLE
Added ability to handle established *sql.DB

### DIFF
--- a/geo.go
+++ b/geo.go
@@ -25,3 +25,14 @@ func HandleWithSQL() (*SQLMapper, error) {
 
 	return nil, sqlConfErr
 }
+
+func HandleWithSQLDb(database *sql.DB) (*SQLMapper, error) {
+	sqlConf, sqlConfErr := GetSQLConf()
+	if sqlConfErr == nil {
+		s := &SQLMapper{conf: sqlConf}
+		s.sqlConn = database
+		return s, nil
+	}
+
+	return nil, sqlConfErr
+}


### PR DESCRIPTION
Added HandleWithSQLDb to handle an already established *sql.DB. Quick solution w/o breaking anything. Should be refactored to avoid code redundancy.
