### PR TITLE
Master

### DIFF
--- a/google_geocoder.go
+++ b/google_geocoder.go
@@ -46,7 +46,7 @@ func (g *GoogleGeocoder) Geocode(query string) (*Point, error) {
 
 	lat, lng, err := g.extractLatLngFromResponse(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	p := &Point{lat: lat, lng: lng}

--- a/google_geocoder_test.go
+++ b/google_geocoder_test.go
@@ -32,7 +32,11 @@ func TestExtractLatLngFromRequest(t *testing.T) {
 		t.Error("%v\n", err)
 	}
 
-	lat, lng := g.extractLatLngFromResponse(data)
+	lat, lng, err := g.extractLatLngFromResponse(data)
+	if err != nil {
+		t.Error("%v\n", err)
+	}
+
 	if lat != 37.615223 && lng != -122.389979 {
 		t.Error(fmt.Sprintf("Expected: [37.615223, -122.389979], Got: [%f, %f]", lat, lng))
 	}


### PR DESCRIPTION
golang-geo shouldn't panic when there are no results returned from Google geocoding API (ie. when the address is invalid).

I used the "status" message from the Google API as the error message returned (`ZERO_RESULTS`). 

Please let me know if there's anything I need to fix up!

Cheers ~
