### PR TITLE
fixed docs: method calculates with kilometers, not with meters

### DIFF
--- a/point.go
+++ b/point.go
@@ -35,7 +35,7 @@ func (p *Point) Lng() float64 {
 }
 
 // Returns a Point populated with the lat and lng coordinates
-// by transposing the origin point the passed in distance (in meters)
+// by transposing the origin point the passed in distance (in kilometers)
 // by the passed in compass bearing (in degrees).
 // Original Implementation from: http://www.movable-type.co.uk/scripts/latlong.html
 func (p *Point) PointAtDistanceAndBearing(dist float64, bearing float64) *Point {


### PR DESCRIPTION
This method actually calculates with kilometers, not with meters as specified in the docs.
For now i fixed the docs.
Better would be to discuss, if it makes more sense to prepend a division by 1000 inside the method before working with the distance-parameter to make the code behave according to the docs.

I suggest leaving it as is due to the fact that in everyday-use of GIS-stuff, we usually calculate routes for cars and bicycles, stuff like that. In this field, the kilometer is a better handleable dimension.
