### PR TITLE
use Point whenever possible

### DIFF
--- a/google_geocoder.go
+++ b/google_geocoder.go
@@ -74,29 +74,27 @@ func (g *GoogleGeocoder) Geocode(query string) (*Point, error) {
 		return nil, err
 	}
 
-	lat, lng, err := g.extractLatLngFromResponse(data)
+	point, err := g.extractLatLngFromResponse(data)
 	if err != nil {
 		return nil, err
 	}
 
-	p := &Point{lat: lat, lng: lng}
-
-	return p, nil
+	return &point, nil
 }
 
-// Extracts the first lat and lng values from a Google Geocoder Response body.
-func (g *GoogleGeocoder) extractLatLngFromResponse(data []byte) (float64, float64, error) {
+// Extracts the first location from a Google Geocoder Response body.
+func (g *GoogleGeocoder) extractLatLngFromResponse(data []byte) (Point, error) {
 	res := &googleGeocodeResponse{}
 	json.Unmarshal(data, &res)
 
 	if len(res.Results) == 0 {
-		return 0, 0, googleZeroResultsError
+		return Point{}, googleZeroResultsError
 	}
 
 	lat := res.Results[0].Geometry.Location.Lat
 	lng := res.Results[0].Geometry.Location.Lng
 
-	return lat, lng, nil
+	return Point{lat, lng}, nil
 }
 
 // Reverse geocodes the pointer to a Point struct and returns the first address that matches

--- a/google_geocoder_test.go
+++ b/google_geocoder_test.go
@@ -32,13 +32,13 @@ func TestExtractLatLngFromRequest(t *testing.T) {
 		t.Error("%v\n", err)
 	}
 
-	lat, lng, err := g.extractLatLngFromResponse(data)
+	point, err := g.extractLatLngFromResponse(data)
 	if err != nil {
 		t.Error("%v\n", err)
 	}
 
-	if lat != 37.615223 || lng != -122.389979 {
-		t.Error(fmt.Sprintf("Expected: [37.615223, -122.389979], Got: [%f, %f]", lat, lng))
+	if point.lat != 37.615223 || point.lng != -122.389979 {
+		t.Error(fmt.Sprintf("Expected: [37.615223, -122.389979], Got: [%f, %f]", point.lat, point.lng))
 	}
 }
 
@@ -51,7 +51,7 @@ func TestExtractLatLngFromRequestZeroResults(t *testing.T) {
 		t.Error("%v\n", err)
 	}
 
-	_, _, err = g.extractLatLngFromResponse(data)
+	_, err = g.extractLatLngFromResponse(data)
 	if err != googleZeroResultsError {
 		t.Error(fmt.Sprintf("Expected error: %v, Got: %v"), googleZeroResultsError, err)
 	}

--- a/mapquest_geocoder.go
+++ b/mapquest_geocoder.go
@@ -63,29 +63,27 @@ func (g *MapQuestGeocoder) Geocode(query string) (*Point, error) {
 		return nil, err
 	}
 
-	lat, lng, extractErr := g.extractLatLngFromResponse(data)
+	point, extractErr := g.extractLatLngFromResponse(data)
 	if extractErr != nil {
 		return nil, extractErr
 	}
 
-	p := &Point{lat: lat, lng: lng}
-
-	return p, nil
+	return &point, nil
 }
 
-// Extracts the first lat and lng values from a MapQuest response body.
-func (g *MapQuestGeocoder) extractLatLngFromResponse(data []byte) (float64, float64, error) {
+// Extracts the first location from a MapQuest response body.
+func (g *MapQuestGeocoder) extractLatLngFromResponse(data []byte) (Point, error) {
 	res := make([]map[string]interface{}, 0)
 	json.Unmarshal(data, &res)
 
 	if len(res) == 0 {
-		return 0, 0, mapquestZeroResultsError
+		return Point{}, mapquestZeroResultsError
 	}
 
 	lat, _ := strconv.ParseFloat(res[0]["lat"].(string), 64)
 	lng, _ := strconv.ParseFloat(res[0]["lon"].(string), 64)
 
-	return lat, lng, nil
+	return Point{lat, lng}, nil
 }
 
 // Returns the first most available address that corresponds to the passed in point.

--- a/mapquest_geocoder_test.go
+++ b/mapquest_geocoder_test.go
@@ -14,13 +14,13 @@ func TestMapQuestExtractLatLngFromRequest(t *testing.T) {
 		t.Error("%v\n", err)
 	}
 
-	lat, lng, err := g.extractLatLngFromResponse(data)
+	point, err := g.extractLatLngFromResponse(data)
 	if err != nil {
 		t.Error("%v\n", err)
 	}
 
-	if lat != 37.62181845 || lng != -122.383992092462 {
-		t.Error(fmt.Sprintf("Expected: [37.62181845, -122.383992092462], Got: [%f, %f]", lat, lng))
+	if point.lat != 37.62181845 || point.lng != -122.383992092462 {
+		t.Error(fmt.Sprintf("Expected: [37.62181845, -122.383992092462], Got: [%f, %f]", point.lat, point.lng))
 	}
 }
 
@@ -33,7 +33,7 @@ func TestMapQuestExtractLatLngFromRequestZeroResults(t *testing.T) {
 		t.Error("%v\n", err)
 	}
 
-	_, _, err = g.extractLatLngFromResponse(data)
+	_, err = g.extractLatLngFromResponse(data)
 	if err != mapquestZeroResultsError {
 		t.Error(fmt.Sprintf("Expected error: %v, Got: %v"), mapquestZeroResultsError, err)
 	}

--- a/opencage_geocoder.go
+++ b/opencage_geocoder.go
@@ -17,12 +17,13 @@ type OpenCageGeocoder struct{}
 type opencageGeocodeResponse struct {
 	Results []struct {
 		Formatted string `json:"formatted"`
-		Geometry struct {
+		Geometry  struct {
 			Lat float64
 			Lng float64
 		}
 	}
 }
+
 // This is the error that consumers receive when there
 // are no results from the geocoding request.
 var opencageZeroResultsError = errors.New("ZERO_RESULTS")
@@ -72,33 +73,30 @@ func (g *OpenCageGeocoder) Geocode(query string) (*Point, error) {
 		return nil, err
 	}
 
-	lat, lng, extractErr := g.extractLatLngFromResponse(data)
+	point, extractErr := g.extractLatLngFromResponse(data)
 	if extractErr != nil {
 		return nil, extractErr
 	}
 
-	p := &Point{lat: lat, lng: lng}
-
-	return p, nil
+	return &point, nil
 }
 
-// Extracts the first lat and lng values from a OpenCage response body.
-func (g *OpenCageGeocoder) extractLatLngFromResponse(data []byte) (float64, float64, error) {
+// Extracts the first location from a OpenCage response body.
+func (g *OpenCageGeocoder) extractLatLngFromResponse(data []byte) (Point, error) {
 	res := &opencageGeocodeResponse{}
 	json.Unmarshal(data, &res)
 
 	// fmt.Printf("%s\n", data)
 	// fmt.Printf("%v\n", res)
 
-
 	if len(res.Results) == 0 {
-		return 0, 0, opencageZeroResultsError
+		return Point{}, opencageZeroResultsError
 	}
 
 	lat := res.Results[0].Geometry.Lat
 	lng := res.Results[0].Geometry.Lng
 
-	return lat, lng, nil
+	return Point{lat, lng}, nil
 }
 
 // Returns the first most available address that corresponds to the passed in point.

--- a/opencage_geocoder_test.go
+++ b/opencage_geocoder_test.go
@@ -14,13 +14,13 @@ func TestOpenCageExtractLatLngFromRequest(t *testing.T) {
 		t.Error("%v\n", err)
 	}
 
-	lat, lng, err := g.extractLatLngFromResponse(data)
+	point, err := g.extractLatLngFromResponse(data)
 	if err != nil {
 		t.Error("%v\n", err)
 	}
 
-	if lat != -23.5373732 || lng != -46.8374628 {
-		t.Error(fmt.Sprintf("Expected: [-23.5373732, -46.8374628], Got: [%f, %f]", lat, lng))
+	if point.lat != -23.5373732 || point.lng != -46.8374628 {
+		t.Error(fmt.Sprintf("Expected: [-23.5373732, -46.8374628], Got: [%f, %f]", point.lat, point.lng))
 	}
 }
 
@@ -48,7 +48,7 @@ func TestOpenCageExtractLatLngFromRequestZeroResults(t *testing.T) {
 		t.Error("%v\n", err)
 	}
 
-	_, _, err = g.extractLatLngFromResponse(data)
+	_, err = g.extractLatLngFromResponse(data)
 	if err != opencageZeroResultsError {
 		t.Error(fmt.Sprintf("Expected error: %v, Got: %v"), opencageZeroResultsError, err)
 	}

--- a/point.go
+++ b/point.go
@@ -103,7 +103,7 @@ func (p *Point) BearingTo(p2 *Point) float64 {
 // Renders the current Point to valid JSON.
 // Implements the json.Marshaller Interface.
 func (p *Point) MarshalJSON() ([]byte, error) {
-	res := fmt.Sprintf(`{"lat":%v, "lng":%v}`, p.Lat(), p.Lng())
+	res := fmt.Sprintf(`{"lat":%v, "lng":%v}`, p.lat, p.lng)
 	return []byte(res), nil
 }
 

--- a/point_test.go
+++ b/point_test.go
@@ -115,7 +115,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Errorf("Should not encounter an error when attempting to Unmarshal a Point from JSON")
 	}
 
-	if p.Lat() != 40.7486 || p.Lng() != -73.9864 {
+	if p.lat != 40.7486 || p.lng != -73.9864 {
 		t.Errorf("Point has mismatched data after Unmarshalling from JSON")
 	}
 }

--- a/polygon.go
+++ b/polygon.go
@@ -68,7 +68,7 @@ func (p *Polygon) Contains(point *Point) bool {
 func (p *Polygon) intersectsWithRaycast(point *Point, start *Point, end *Point) bool {
 	// Always ensure that the the first point
 	// has a y coordinate that is less than the second point
-	if start.Lng() > end.Lng() {
+	if start.lng > end.lng {
 
 		// Switch the points if otherwise.
 		start, end = end, start
@@ -78,35 +78,35 @@ func (p *Polygon) intersectsWithRaycast(point *Point, start *Point, end *Point) 
 	// Move the point's y coordinate
 	// outside of the bounds of the testing region
 	// so we can start drawing a ray
-	for point.Lng() == start.Lng() || point.Lng() == end.Lng() {
-		newLng := math.Nextafter(point.Lng(), math.Inf(1))
-		point = NewPoint(point.Lat(), newLng)
+	for point.lng == start.lng || point.lng == end.lng {
+		newLng := math.Nextafter(point.lng, math.Inf(1))
+		point = NewPoint(point.lat, newLng)
 	}
 
 	// If we are outside of the polygon, indicate so.
-	if point.Lng() < start.Lng() || point.Lng() > end.Lng() {
+	if point.lng < start.lng || point.lng > end.lng {
 		return false
 	}
 
-	if start.Lat() > end.Lat() {
-		if point.Lat() > start.Lat() {
+	if start.lat > end.lat {
+		if point.lat > start.lat {
 			return false
 		}
-		if point.Lat() < end.Lat() {
+		if point.lat < end.lat {
 			return true
 		}
 
 	} else {
-		if point.Lat() > end.Lat() {
+		if point.lat > end.lat {
 			return false
 		}
-		if point.Lat() < start.Lat() {
+		if point.lat < start.lat {
 			return true
 		}
 	}
 
-	raySlope := (point.Lng() - start.Lng()) / (point.Lat() - start.Lat())
-	diagSlope := (end.Lng() - start.Lng()) / (end.Lat() - start.Lat())
+	raySlope := (point.lng - start.lng) / (point.lat - start.lat)
+	diagSlope := (end.lng - start.lng) / (end.lat - start.lat)
 
 	return raySlope >= diagSlope
 }


### PR DESCRIPTION
Hi again Kelly

I've made 2 changes. Please give them a review.
1. use Point's lat/lng whenever possible
   I keep Point's Lat() and Lng() for now. but if you think it's a good idea to make lat/lng visible (Lat/Lng), we can drop the 2 getters later.
2. use Point value (instead of 2 float64 values) in 3 geocoders
   I think it makes method signature simpler and takes advantage of zero-valued Point{}.

All changes are formatted and tested.

Cheers
Jerry
