### PR TITLE
Removing unecessary pointer dereferencing to json unmarshal calls

### DIFF
--- a/google_geocoder.go
+++ b/google_geocoder.go
@@ -91,7 +91,7 @@ func (g *GoogleGeocoder) Geocode(query string) (*Point, error) {
 // Extracts the first location from a Google Geocoder Response body.
 func (g *GoogleGeocoder) extractLatLngFromResponse(data []byte) (Point, error) {
 	res := &googleGeocodeResponse{}
-	json.Unmarshal(data, &res)
+	json.Unmarshal(data, res)
 
 	if len(res.Results) == 0 {
 		return Point{}, googleZeroResultsError

--- a/google_geocoder.go
+++ b/google_geocoder.go
@@ -119,7 +119,7 @@ func (g *GoogleGeocoder) ReverseGeocode(p *Point) (string, error) {
 // Returns an Address from a Google Geocoder Response body.
 func (g *GoogleGeocoder) extractAddressFromResponse(data []byte) (string, error) {
 	res := &googleGeocodeResponse{}
-	err := json.Unmarshal(data, &res)
+	err := json.Unmarshal(data, res)
 
 	if err != nil {
 		return "", err

--- a/opencage_geocoder.go
+++ b/opencage_geocoder.go
@@ -115,7 +115,7 @@ func (g *OpenCageGeocoder) ReverseGeocode(p *Point) (string, error) {
 // Return sthe first address in the passed in byte array.
 func (g *OpenCageGeocoder) extractAddressFromResponse(data []byte) string {
 	res := &opencageGeocodeResponse{}
-	json.Unmarshal(data, &res)
+	json.Unmarshal(data, res)
 
 	resStr := res.Results[0].Formatted
 	return resStr

--- a/opencage_geocoder.go
+++ b/opencage_geocoder.go
@@ -84,7 +84,7 @@ func (g *OpenCageGeocoder) Geocode(query string) (*Point, error) {
 // Extracts the first location from a OpenCage response body.
 func (g *OpenCageGeocoder) extractLatLngFromResponse(data []byte) (Point, error) {
 	res := &opencageGeocodeResponse{}
-	json.Unmarshal(data, &res)
+	json.Unmarshal(data, res)
 
 	// fmt.Printf("%s\n", data)
 	// fmt.Printf("%v\n", res)


### PR DESCRIPTION
As mentioned in #37 , there's unnecessary pointer arithmetic in the json unmarshal calls.

This pull request attempts to resolve these issues in both the google_gecoder and opencage_geocoder files.

( +cc @enj to review)