### PR TITLE
Google geocoder should use HTTPS in the request URL, not HTTP

### DIFF
--- a/google_geocoder.go
+++ b/google_geocoder.go
@@ -40,7 +40,7 @@ type googleReverseGeocodeResponse struct {
 var googleZeroResultsError = errors.New("ZERO_RESULTS")
 
 // This contains the base URL for the Google Geocoder API.
-var googleGeocodeURL = "http://maps.googleapis.com/maps/api/geocode/json"
+var googleGeocodeURL = "https://maps.googleapis.com/maps/api/geocode/json"
 
 var GoogleAPIKey = ""
 


### PR DESCRIPTION
This PR changes the Google Geocoder URL to point at the HTTPS Geocoding URL

@kellydunn 