### PR TITLE
Add support for Google Maps API For Work params

### DIFF
--- a/google_geocoder_test.go
+++ b/google_geocoder_test.go
@@ -22,55 +22,50 @@ func TestSetGoogleGeocodeURL(t *testing.T) {
 	}
 }
 
-func TestGoogleGeocoderQueryStr(t *testing.T) {
-	// Empty API Key
-	SetGoogleAPIKey("")
+func TestGoogleGeocodeQueryStr(t *testing.T) {
 	address := "123 fake st"
-	res, err := googleGeocodeQueryStr(address)
-	if err != nil {
-		t.Errorf("Error creating query string: %v", err)
-	}
+
+	res := googleGeocodeQueryStr(address)
 
 	expected := "address=123+fake+st"
 	if res != expected {
 		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
 	}
-
-	// Set api key to some value
-	SetGoogleAPIKey("foo")
-	res, err = googleGeocodeQueryStr(address)
-	if err != nil {
-		t.Errorf("Error creating query string: %v", err)
-	}
-
-	expected = "address=123+fake+st&key=foo"
-	if res != expected {
-		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
-	}
 }
 
-func TestGoogleReverseGeocoderQueryStr(t *testing.T) {
-	// Empty API Key
-	SetGoogleAPIKey("")
+func TestGoogleReverseGeocodeQueryStr(t *testing.T) {
 	p := &Point{lat: 123.45, lng: 56.78}
-	res, err := googleReverseGeocodeQueryStr(p)
-	if err != nil {
-		t.Errorf("Error creating query string: %v", err)
-	}
+	res := googleReverseGeocodeQueryStr(p)
 
 	expected := "latlng=123.450000,56.780000"
 	if res != expected {
 		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
 	}
+}
 
-	// Set api key to some value
-	SetGoogleAPIKey("foo")
-	res, err = googleReverseGeocodeQueryStr(p)
+func TestGoogleFormattedRequestStr(t *testing.T) {
+	// Empty API Key
+	SetGoogleAPIKey("")
+	params := "latlng=123.450000,56.780000"
+
+	res, err := googleFormattedRequestStr(params)
 	if err != nil {
 		t.Errorf("Error creating query string: %v", err)
 	}
 
-	expected = "latlng=123.450000,56.780000&key=foo"
+	expected := "sensor=false&latlng=123.450000,56.780000"
+	if res != expected {
+		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
+	}
+
+	// Set api key to some value
+	SetGoogleAPIKey("foo")
+	res, err = googleFormattedRequestStr(params)
+	if err != nil {
+		t.Errorf("Error creating query string: %v", err)
+	}
+
+	expected = "sensor=false&latlng=123.450000,56.780000&key=foo"
 	if res != expected {
 		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
 	}

--- a/google_geocoder_test.go
+++ b/google_geocoder_test.go
@@ -70,7 +70,8 @@ func TestGoogleFormattedRequestStr(t *testing.T) {
 	SetGoogleClientID("")
 	params := "latlng=123.450000,56.780000"
 
-	res, err := googleFormattedRequestStr(params)
+	g := &GoogleGeocoder{}
+	res, err := g.googleFormattedRequestStr(params)
 	if err != nil {
 		t.Errorf("Error creating query string: %v", err)
 	}
@@ -82,7 +83,9 @@ func TestGoogleFormattedRequestStr(t *testing.T) {
 
 	// Set api key to some value
 	SetGoogleAPIKey("foo")
-	res, err = googleFormattedRequestStr(params)
+
+	g.AuthSchema = GoogleMapsAPIToken
+	res, err = g.googleFormattedRequestStr(params)
 	if err != nil {
 		t.Errorf("Error creating query string: %v", err)
 	}
@@ -99,7 +102,8 @@ func TestGoogleFormattedRequestStr(t *testing.T) {
 	SetGoogleChannel("")
 	params = "address=New+York"
 
-	res, err = googleFormattedRequestStr(params)
+	g.AuthSchema = GoogleMapsForWorkAuth
+	res, err = g.googleFormattedRequestStr(params)
 	if err != nil {
 		t.Errorf("Error creating query string: %v", err)
 	}
@@ -111,7 +115,7 @@ func TestGoogleFormattedRequestStr(t *testing.T) {
 
 	// Set Channel
 	SetGoogleChannel("chan")
-	res, err = googleFormattedRequestStr(params)
+	res, err = g.googleFormattedRequestStr(params)
 	if err != nil {
 		t.Errorf("Error creating query string: %v", err)
 	}

--- a/google_geocoder_test.go
+++ b/google_geocoder_test.go
@@ -22,6 +22,27 @@ func TestSetGoogleGeocodeURL(t *testing.T) {
 	}
 }
 
+func TestSetGoogleClientID(t *testing.T) {
+	SetGoogleClientID("foo")
+	if GoogleClientID != "foo" {
+		t.Errorf("Mismatched value for GoogleClientID.  Expected: 'foo', Actual: %s", GoogleAPIKey)
+	}
+}
+
+func TestSetGooglePrivateKey(t *testing.T) {
+	SetGooglePrivateKey("foo")
+	if GooglePrivateKey != "foo" {
+		t.Errorf("Mismatched value for GooglePrivateKey.  Expected: 'foo', Actual: %s", GoogleAPIKey)
+	}
+}
+
+func TestSetGoogleChannel(t *testing.T) {
+	SetGoogleChannel("foo")
+	if GoogleChannel != "foo" {
+		t.Errorf("Mismatched value for GoogleChannel.  Expected: 'foo', Actual: %s", GoogleAPIKey)
+	}
+}
+
 func TestGoogleGeocodeQueryStr(t *testing.T) {
 	address := "123 fake st"
 
@@ -44,8 +65,9 @@ func TestGoogleReverseGeocodeQueryStr(t *testing.T) {
 }
 
 func TestGoogleFormattedRequestStr(t *testing.T) {
-	// Empty API Key
+	// Empty API Key and Client ID
 	SetGoogleAPIKey("")
+	SetGoogleClientID("")
 	params := "latlng=123.450000,56.780000"
 
 	res, err := googleFormattedRequestStr(params)
@@ -66,6 +88,35 @@ func TestGoogleFormattedRequestStr(t *testing.T) {
 	}
 
 	expected = "sensor=false&latlng=123.450000,56.780000&key=foo"
+	if res != expected {
+		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
+	}
+
+	// Set Client ID and Private Key to some value
+	SetGoogleAPIKey("")
+	SetGoogleClientID("clientID")
+	SetGooglePrivateKey("vNIXE0xscrmjlyV-12Nj_BvUPaw=")
+	SetGoogleChannel("")
+	params = "address=New+York"
+
+	res, err = googleFormattedRequestStr(params)
+	if err != nil {
+		t.Errorf("Error creating query string: %v", err)
+	}
+
+	expected = "sensor=false&address=New+York&client=clientID&signature=N5nLIw-ytshbH2swgE9pzmZaIjU="
+	if res != expected {
+		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
+	}
+
+	// Set Channel
+	SetGoogleChannel("chan")
+	res, err = googleFormattedRequestStr(params)
+	if err != nil {
+		t.Errorf("Error creating query string: %v", err)
+	}
+
+	expected = "sensor=false&address=New+York&channel=chan&client=clientID&signature=UKgre7hzowedRuWgv8NfwnOoTCc="
 	if res != expected {
 		t.Errorf(fmt.Sprintf("Mismatched query string.  Expected: %s.  Actual: %s", expected, res))
 	}


### PR DESCRIPTION
The Maps API can be used with a Google business account but this require a different authentication method than a simple API key and request URL signing.

This Pull Request adds support for this auth method based on the documentation provided here: https://developers.google.com/maps/documentation/business/webservices/auth

I reused the same `GoogleGeocoder` but added 3 new vars and their matching configuration functions.