### PR TITLE
Bearing must be between 0 and 360 degrees

### DIFF
--- a/point.go
+++ b/point.go
@@ -98,6 +98,10 @@ func (p *Point) BearingTo(p2 *Point) float64 {
 		math.Sin(lat1)*math.Cos(lat2)*math.Cos(dLon)
 	brng := math.Atan2(y, x) * 180.0 / math.Pi
 
+	if brng < 0. {
+		brng = 360. + brng
+	}
+
 	return brng
 }
 

--- a/point_test.go
+++ b/point_test.go
@@ -92,6 +92,19 @@ func TestBearingTo(t *testing.T) {
 	}
 }
 
+func TestBearingToBetween0to360(t *testing.T) {
+	p1 := &Point{lat: -25.5316666666667, lng: -49.1761111111111}
+	p2 := &Point{lat: 40.63980103, lng: -73.77890015}
+	bearing := p1.BearingTo(p2)
+
+	// Expected bearing between 0 and 360 degrees
+	withinBearingBounds := 0. < bearing && bearing <= 360.
+
+	if !withinBearingBounds {
+		t.Error("Unnacceptable result.", fmt.Sprintf("%f", bearing))
+	}
+}
+
 func TestMidpointTo(t *testing.T) {
 	p1 := &Point{lat: 52.205, lng: 0.119}
 	p2 := &Point{lat: 48.857, lng: 2.351}


### PR DESCRIPTION
BearingTo returning negative values:

    SBCT := geo.NewPoint(-25.5316666666667, -49.1761111111111)
    KJFK := geo.NewPoint(40.63980103, -73.77890015)
    bearing := SBCT.BearingTo(KJFK)
    log.Println("Bearing:", bearing)
    // got -19.643493, expected 340.3565066777242

