### PR TITLE
Fixing Corners not in Polygon but edges

### DIFF
--- a/geo_test.go
+++ b/geo_test.go
@@ -3,10 +3,11 @@ package geo
 import (
 	_ "database/sql"
 	"fmt"
-	"github.com/erikstmartin/go-testdb"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/erikstmartin/go-testdb"
 )
 
 // TODO This paticular test is just one big integration for using the entire library.
@@ -24,7 +25,7 @@ func TestPointsWithinRadiusIntegration(t *testing.T) {
 	s, sqlErr := HandleWithSQL()
 
 	if sqlErr != nil {
-		t.Error("ERROR: %s", sqlErr)
+		t.Error("ERROR:", sqlErr)
 	}
 
 	// SFO

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/Wulfheart/golang-geo
+
+go 1.12
+
+require (
+	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5
+	github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28
+	github.com/lib/pq v1.1.1
+	github.com/ziutek/mymysql v1.5.4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
+github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
+github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28 h1:mkl3tvPHIuPaWsLtmHTybJeoVEW7cbePK73Ir8VtruA=
+github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28/go.mod h1:T/T7jsxVqf9k/zYOqbgNAsANsjxTd1Yq3htjDhQ1H0c=
+github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
+github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
+github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=

--- a/mapquest_geocoder_test.go
+++ b/mapquest_geocoder_test.go
@@ -79,14 +79,14 @@ func TestMapquestReverseGeocoderQueryStr(t *testing.T) {
 func TestMapQuestGeocodeFromRequest(t *testing.T) {
 	data, err := GetMockResponse("test/data/mapquest_geocode_success.json")
 	if err != nil {
-		t.Error("%v\n", err)
+		t.Errorf("%v\n", err)
 	}
 
 	res := []*mapQuestGeocodeResponse{}
 
 	err = json.Unmarshal(data, &res)
 	if err != nil {
-		t.Error("%v\n", err)
+		t.Errorf("%v\n", err)
 	}
 
 	if len(res) <= 0 {

--- a/point_test.go
+++ b/point_test.go
@@ -33,7 +33,7 @@ func TestLat(t *testing.T) {
 	lat := p.Lat()
 
 	if lat != 40.5 {
-		t.Error("Expected a call to GetLat() to return the same lat value as was set before, but got %f instead", lat)
+		t.Errorf("Expected a call to GetLat() to return the same lat value as was set before, but got %f instead", lat)
 	}
 }
 
@@ -44,7 +44,7 @@ func TestLng(t *testing.T) {
 	lng := p.Lng()
 
 	if lng != 120.5 {
-		t.Error("Expected a call to GetLng() to return the same lat value as was set before, but got %f instead", lng)
+		t.Errorf("Expected a call to GetLng() to return the same lat value as was set before, but got %f instead", lng)
 	}
 }
 

--- a/polygon.go
+++ b/polygon.go
@@ -49,6 +49,7 @@ func (p *Polygon) Contains(point *Point) bool {
 	}
 
 	// For now it recognizes a point only if it is in the polygon or on an edge. If the point is on one of the corners it returns false, so a quick and dirty array comparison.
+	// Look here for further options: https://github.com/kellydunn/golang-geo/pull/71#discussion_r303040014
 	for _, p := range p.points {
 		if p.lat == point.lat && p.lng == point.lng {
 			return true

--- a/polygon.go
+++ b/polygon.go
@@ -51,6 +51,13 @@ func (p *Polygon) Contains(point *Point) bool {
 		return false
 	}
 
+	// For now it recognizes a point only if it is in the polygon or on an edge. If the point is on one of the corners it returns false, so a quick and dirty array comparison.
+	for _, p := range p.points {
+		if p.lat == point.lat && p.lng == point.lng {
+			return true
+		}
+	}
+
 	start := len(p.points) - 1
 	end := 0
 

--- a/polygon.go
+++ b/polygon.go
@@ -38,7 +38,7 @@ func (p *Polygon) IsClosed() bool {
 	if len(p.points) < 3 {
 		return false
 	}
-	if p.points[0] != p.points[len(p.points)-1] {
+	if *p.points[0] != *p.points[len(p.points)-1] {
 		return false
 	}
 

--- a/polygon.go
+++ b/polygon.go
@@ -38,6 +38,9 @@ func (p *Polygon) IsClosed() bool {
 	if len(p.points) < 3 {
 		return false
 	}
+	if p.points[0] != p.points[len(p.points)-1] {
+		return false
+	}
 
 	return true
 }

--- a/polygon.go
+++ b/polygon.go
@@ -38,9 +38,11 @@ func (p *Polygon) IsClosed() bool {
 	if len(p.points) < 3 {
 		return false
 	}
-	if *p.points[0] != *p.points[len(p.points)-1] {
-		return false
-	}
+
+	// !Currently the following section would break to much older code as it is more strict on the definition of a closed polygon.
+	// if *p.points[0] != *p.points[len(p.points)-1] {
+	// 	return false
+	// }
 
 	return true
 }

--- a/polygon.go
+++ b/polygon.go
@@ -39,11 +39,6 @@ func (p *Polygon) IsClosed() bool {
 		return false
 	}
 
-	// !Currently the following section would break to much older code as it is more strict on the definition of a closed polygon.
-	// if *p.points[0] != *p.points[len(p.points)-1] {
-	// 	return false
-	// }
-
 	return true
 }
 

--- a/polygon_test.go
+++ b/polygon_test.go
@@ -157,7 +157,7 @@ func polygonFromFile(filename string) (*Polygon, error) {
 
 func TestPolygonNotClosed(t *testing.T) {
 	points := []*Point{
-		NewPoint(0, 0), NewPoint(0, 1), NewPoint(1, 1), NewPoint(1, 0),
+		NewPoint(0, 0), NewPoint(0, 1), //! NewPoint(1, 1), NewPoint(1, 0), if stricter rules for a closed polygon apply
 	}
 	poly := NewPolygon(points)
 	if poly.IsClosed() {

--- a/polygon_test.go
+++ b/polygon_test.go
@@ -154,3 +154,56 @@ func polygonFromFile(filename string) (*Polygon, error) {
 
 	return p, nil
 }
+
+func TestPolygonNotClosed(t *testing.T) {
+	points := []*Point{
+		NewPoint(0, 0), NewPoint(0, 1), NewPoint(1, 1), NewPoint(1, 0),
+	}
+	poly := NewPolygon(points)
+	if poly.IsClosed() {
+		t.Error("Nope! The polygon is not closed!")
+	}
+}
+
+func TestPolygonClosed(t *testing.T) {
+	points := []*Point{
+		NewPoint(0, 0), NewPoint(0, 1), NewPoint(1, 1), NewPoint(1, 0), NewPoint(0, 0),
+	}
+	poly := NewPolygon(points)
+	if !poly.IsClosed() {
+		t.Error("Nope! The polygon is closed!")
+	}
+}
+
+type testPoint struct {
+	P        *Point
+	Expected bool
+}
+
+// ntp = newTestPoint
+func ntp(lat float64, lng float64, expectedOutput bool) (t testPoint) {
+	t.P = NewPoint(lat, lng)
+	t.Expected = expectedOutput
+	return t
+}
+func TestPolygonSimple(t *testing.T) {
+	// A closed polygon - however the IsClosed() does not work properly.
+	polygonPoints := []*Point{
+		NewPoint(0, 0), NewPoint(0, 1), NewPoint(1, 1), NewPoint(1, 0), NewPoint(0, 0),
+	}
+
+	testers := []testPoint{
+		ntp(0, 0, true), ntp(0.5, 0.5, true), ntp(9, 9, false), ntp(0.5, 0, true), ntp(0.2, 0.4, true), ntp(1, 0.9, true), ntp(1, 1, true),
+	}
+
+	polygon := NewPolygon(polygonPoints)
+
+	for _, q := range testers {
+		res := polygon.Contains(q.P)
+		if res != q.Expected {
+			t.Log("x: ", q.P.lat, "\ty: ", q.P.lng, "\tExpected: ", q.Expected, "\tGot: ", res)
+			t.Fail()
+		}
+	}
+
+}

--- a/polygon_test.go
+++ b/polygon_test.go
@@ -104,7 +104,7 @@ func TestEquatorGreenwichContains(t *testing.T) {
 	polygon, err := polygonFromFile("test/data/equator_greenwich.json")
 
 	if err != nil {
-		t.Errorf("error parsing polygon", err)
+		t.Errorf("error parsing polygon %v", err)
 	}
 
 	if !polygon.Contains(point1) {

--- a/polygon_test.go
+++ b/polygon_test.go
@@ -193,7 +193,7 @@ func TestPolygonSimple(t *testing.T) {
 	}
 
 	testers := []testPoint{
-		ntp(0, 0, true), ntp(0.5, 0.5, true), ntp(9, 9, false), ntp(0.5, 0, true), ntp(0.2, 0.4, true), ntp(1, 0.9, true), ntp(1, 1, true),
+		ntp(0, 0, true), ntp(0.5, 0.5, true), ntp(9, 9, false), ntp(0.5, 0, true), ntp(0.2, 0.4, true), ntp(1, 0.9, true), ntp(1, 1, true), ntp(0.00000000000000000000009, 0.00000000000000000000000000000001, true),
 	}
 
 	polygon := NewPolygon(polygonPoints)


### PR DESCRIPTION
Corner points are now considered to be in the polygon just like edges. It's a quick and dirty workaround. This adresses #70.