### PR TITLE
Fix bug in point calculations that can cause negative bearings.

### DIFF
--- a/geo_test.go
+++ b/geo_test.go
@@ -3,10 +3,11 @@ package geo
 import (
 	_ "database/sql"
 	"fmt"
-	"github.com/erikstmartin/go-testdb"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/erikstmartin/go-testdb"
 )
 
 // TODO This paticular test is just one big integration for using the entire library.
@@ -24,7 +25,7 @@ func TestPointsWithinRadiusIntegration(t *testing.T) {
 	s, sqlErr := HandleWithSQL()
 
 	if sqlErr != nil {
-		t.Error("ERROR: %s", sqlErr)
+		t.Errorf("ERROR: %s", sqlErr)
 	}
 
 	// SFO

--- a/mapquest_geocoder_test.go
+++ b/mapquest_geocoder_test.go
@@ -79,14 +79,14 @@ func TestMapquestReverseGeocoderQueryStr(t *testing.T) {
 func TestMapQuestGeocodeFromRequest(t *testing.T) {
 	data, err := GetMockResponse("test/data/mapquest_geocode_success.json")
 	if err != nil {
-		t.Error("%v\n", err)
+		t.Errorf("%v\n", err)
 	}
 
 	res := []*mapQuestGeocodeResponse{}
 
 	err = json.Unmarshal(data, &res)
 	if err != nil {
-		t.Error("%v\n", err)
+		t.Errorf("%v\n", err)
 	}
 
 	if len(res) <= 0 {

--- a/point.go
+++ b/point.go
@@ -84,7 +84,7 @@ func (p *Point) GreatCircleDistance(p2 *Point) float64 {
 	return EARTH_RADIUS * c
 }
 
-// BearingTo: Calculates the initial bearing (sometimes referred to as forward azimuth)
+// BearingTo: Calculates the initial bearing in degrees (sometimes referred to as forward azimuth)
 // Original Implementation from: http://www.movable-type.co.uk/scripts/latlong.html
 func (p *Point) BearingTo(p2 *Point) float64 {
 
@@ -97,7 +97,10 @@ func (p *Point) BearingTo(p2 *Point) float64 {
 	x := math.Cos(lat1)*math.Sin(lat2) -
 		math.Sin(lat1)*math.Cos(lat2)*math.Cos(dLon)
 	brng := math.Atan2(y, x) * 180.0 / math.Pi
-
+	// Account for math.Atan2 returning negative values.
+	if brng < 0 {
+		brng = 360 + brng
+	}
 	return brng
 }
 

--- a/point_test.go
+++ b/point_test.go
@@ -33,7 +33,7 @@ func TestLat(t *testing.T) {
 	lat := p.Lat()
 
 	if lat != 40.5 {
-		t.Error("Expected a call to GetLat() to return the same lat value as was set before, but got %f instead", lat)
+		t.Errorf("Expected a call to GetLat() to return the same lat value as was set before, but got %f instead", lat)
 	}
 }
 
@@ -44,7 +44,7 @@ func TestLng(t *testing.T) {
 	lng := p.Lng()
 
 	if lng != 120.5 {
-		t.Error("Expected a call to GetLng() to return the same lat value as was set before, but got %f instead", lng)
+		t.Errorf("Expected a call to GetLng() to return the same lat value as was set before, but got %f instead", lng)
 	}
 }
 

--- a/point_test.go
+++ b/point_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"testing"
 )
 
@@ -79,16 +80,33 @@ func TestPointAtDistanceAndBearing(t *testing.T) {
 }
 
 func TestBearingTo(t *testing.T) {
-	p1 := &Point{lat: 40.7486, lng: -73.9864}
-	p2 := &Point{lat: 0.0, lng: 0.0}
-	bearing := p1.BearingTo(p2)
+	for _, tt := range []struct {
+		name string
+		p1   *Point
+		p2   *Point
+		want float64
+	}{
+		{
+			name: "Basic",
+			p1:   &Point{lat: 40.7486, lng: -73.9864},
+			p2:   &Point{lat: 0.0, lng: 0.0},
+			want: 100.610833,
+		},
+		{
+			name: "NegativeArctan",
+			p1:   &Point{lat: 33.9271, lng: -118.2438},
+			p2:   &Point{lat: 33.9225, lng: -118.3434},
+			want: 266.842019,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Expected bearing 60 degrees
-	resultBearing := 100.610833
-
-	withinBearingBounds := bearing < resultBearing+0.001 && bearing > resultBearing-0.001
-	if !withinBearingBounds {
-		t.Error("Unnacceptable result.", fmt.Sprintf("%f", bearing))
+			got := tt.p1.BearingTo(tt.p2)
+			if diff := math.Abs(got - tt.want); diff > 0.001 {
+				t.Errorf("p1.BearingTo(p2) = %f want %f", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/polygon_test.go
+++ b/polygon_test.go
@@ -104,7 +104,7 @@ func TestEquatorGreenwichContains(t *testing.T) {
 	polygon, err := polygonFromFile("test/data/equator_greenwich.json")
 
 	if err != nil {
-		t.Errorf("error parsing polygon", err)
+		t.Errorf("error parsing polygon: %v", err)
 	}
 
 	if !polygon.Contains(point1) {


### PR DESCRIPTION
Because Atan2 can return a negative result, it is possible for `p1.BearingTo(p2)` to return negative values. I added a check to consider this case, and corresponding tests.

There were also some build warnings due to missing/present format specifiers in tests, and those were fixed as well.